### PR TITLE
SDKAND-458 check if push token is not null before calling sdk method

### DIFF
--- a/app/src/main/java/com/onegini/mobile/exampleapp/network/fcm/FCMRegistrationService.java
+++ b/app/src/main/java/com/onegini/mobile/exampleapp/network/fcm/FCMRegistrationService.java
@@ -18,10 +18,12 @@ package com.onegini.mobile.exampleapp.network.fcm;
 
 import android.content.Context;
 import android.util.Log;
+import android.widget.Toast;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.onegini.mobile.exampleapp.BuildConfig;
 import com.onegini.mobile.exampleapp.OneginiSDK;
+import com.onegini.mobile.exampleapp.R;
 import com.onegini.mobile.exampleapp.storage.FCMStorage;
 import com.onegini.mobile.sdk.android.client.UserClient;
 import com.onegini.mobile.sdk.android.handlers.OneginiMobileAuthWithPushEnrollmentHandler;
@@ -78,8 +80,12 @@ public class FCMRegistrationService {
   private void register() {
     FirebaseApp.initializeApp(context);
     String fcmRefreshToken = FirebaseInstanceId.getInstance().getToken();
-    enrollForMobileAuthentication(fcmRefreshToken);
-    storeRegisteredId(fcmRefreshToken);
+    if (fcmRefreshToken == null) {
+      Toast.makeText(context, context.getString(R.string.push_token_is_null_error_message), Toast.LENGTH_LONG).show();
+    } else {
+      enrollForMobileAuthentication(fcmRefreshToken);
+      storeRegisteredId(fcmRefreshToken);
+    }
   }
 
   private void storeRegisteredId(final String regid) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,5 @@
     <string name="change_pin_finished_succesfully">Change PIN action finished successfully</string>
     <string name="btn_mobile_auth_with_otp_label">Mobile auth with OTP</string>
     <string name="btn_auth_cancel_label">CANCEL</string>
+    <string name="push_token_is_null_error_message">The push token is null, check if your Firebase configuration in google-services.json file is valid.</string>
 </resources>


### PR DESCRIPTION
Error was caused by calling SDK method with null push token. That's way I'm fixing it here and not in the sdk.